### PR TITLE
Feature/company 동행 게시글 수정 페이지 

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,6 @@ const nextConfig = {
       },
     ]
   },
-  lessVarsFilePath: './styles/variables.less', // Path to your LESS variables file (optional)
   reactStrictMode: true, // Strict mode for React
   swcMinify: true, // Enables SWC for minification
 
@@ -19,6 +18,10 @@ const nextConfig = {
   webpack(config) {
     // Any custom webpack configuration here
     return config
+  },
+
+  experimental: {
+    missingSuspenseWithCSRBailout: false,
   },
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "date-fns": "^3.6.0",
         "next": "14.2.5",
         "next-plugin-antd-less": "^1.8.0",
-        "react": "^18",
-        "react-dom": "^18",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "use-debounce": "^10.0.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "date-fns": "^3.6.0",
     "next": "14.2.5",
     "next-plugin-antd-less": "^1.8.0",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "use-debounce": "^10.0.2"
   },
   "devDependencies": {

--- a/src/app/(main)/accompany/[id]/page.tsx
+++ b/src/app/(main)/accompany/[id]/page.tsx
@@ -86,7 +86,12 @@ export default function AccompanyDetailPage() {
             </p>
           </div>
           <div className='flex gap-2'>
-            <button className='text-sm text-main'>수정</button>
+            <button
+              onClick={() => router.push(`/accompany/edit/${id}`)}
+              className='text-sm text-main'
+            >
+              수정
+            </button>
             <button
               className='text-sm text-main'
               onClick={() => handleDeleteClick('게시글')}

--- a/src/app/(main)/accompany/create/page.tsx
+++ b/src/app/(main)/accompany/create/page.tsx
@@ -6,6 +6,7 @@ import { accompanyAreas } from '@/app/data/accompanyAreas'
 import { formatFormData } from '@/app/utils/formUtils'
 import { useRouter } from 'next/navigation'
 import { useCustomMessage } from '@/app/utils/alertUtils' // 메시지 유틸리티 가져오기
+import dayjs from 'dayjs'
 
 const { TextArea } = Input
 
@@ -17,13 +18,14 @@ export default function CreateAccompanyPage() {
   const handleFinish = (values: {
     title: string
     accompany_area: string
-    startDate: Date | null
-    endDate: Date | null
+    startDate: dayjs.Dayjs | null
+    endDate: dayjs.Dayjs | null
     content: string
     custom_url: string | null
   }) => {
     try {
       const formData = formatFormData(values) // 유틸리티 함수 사용하여 데이터 처리
+      console.log('formData:', formData)
 
       // 여기서 실제 API 요청을 보낼 예정
       // 예: await api.submitForm(formData);
@@ -43,7 +45,7 @@ export default function CreateAccompanyPage() {
   return (
     <div className='w-full p-6 mb-4'>
       {contextHolder} {/* alert 표시를 위한 컨텍스트 */}
-      <h1 className='text-lg font-bold text-black'>동행 게시판 작성</h1>
+      <h1 className='text-lg font-bold text-black'>동행 게시글 작성</h1>
       <div className='flex flex-col gap-8 w-full'>
         <Form form={form} onFinish={handleFinish} layout='vertical'>
           <Form.Item
@@ -116,7 +118,7 @@ export default function CreateAccompanyPage() {
           <Form.Item>
             <div className='flex justify-end gap-4'>
               <Button type='default' onClick={() => form.resetFields()}>
-                취소
+                게시글 초기화
               </Button>
               <Button type='primary' htmlType='submit'>
                 작성

--- a/src/app/(main)/accompany/edit/[id]/page.tsx
+++ b/src/app/(main)/accompany/edit/[id]/page.tsx
@@ -1,0 +1,152 @@
+// /accompany/edit/[id]/page.tsx
+
+'use client'
+
+import React, { useEffect } from 'react'
+import { Input, DatePicker, Select, Button, Form } from 'antd'
+import { accompanyAreas } from '@/app/data/accompanyAreas'
+import { formatFormData } from '@/app/utils/formUtils'
+import { useRouter, useParams } from 'next/navigation'
+import { useCustomMessage } from '@/app/utils/alertUtils'
+import dayjs from 'dayjs'
+import { mockData } from '@/app/data/mockDataPost' // mockData import
+
+const { TextArea } = Input
+
+export default function EditAccompanyPage() {
+  const [form] = Form.useForm()
+  const router = useRouter()
+  const { id } = useParams() // 동적 라우팅에서 id 가져오기
+  const { contextHolder, showSuccess, showError } = useCustomMessage()
+
+  useEffect(() => {
+    // mockData에서 해당 id에 맞는 데이터 찾기
+    const post = mockData.find((item) => item.id === parseInt(id as string, 10))
+
+    if (post) {
+      // 폼 초기값 설정
+      form.setFieldsValue({
+        title: post.title,
+        accompany_area: post.accompany_area,
+        startDate: dayjs(post.start_date),
+        endDate: dayjs(post.end_date),
+        content: post.content,
+        custom_url: post.custom_url,
+      })
+    }
+  }, [id, form])
+
+  const handleFinish = (values: {
+    title: string
+    accompany_area: string
+    startDate: dayjs.Dayjs | null
+    endDate: dayjs.Dayjs | null
+    content: string
+    custom_url: string | null
+  }) => {
+    try {
+      const formData = formatFormData(values)
+      console.log('formData:', formData)
+
+      // 실제 API 요청을 보낼 예정 (예: await api.updateForm(formData, id);)
+      // 성공 alert 표시
+      showSuccess('게시글 수정이 완료되었습니다.')
+
+      // alert 보여주기 위해 1초 뒤에 페이지 이동
+      setTimeout(() => {
+        router.push('/accompany')
+      }, 1000) // 1초(1000ms) 후에 페이지 이동
+    } catch (error) {
+      showError('게시글 수정에 실패했습니다.')
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <div className='w-full p-6 mb-4'>
+      {contextHolder} {/* alert 표시를 위한 컨텍스트 */}
+      <h1 className='text-lg font-bold text-black'>동행 게시판 수정</h1>
+      <div className='flex flex-col gap-8 w-full'>
+        <Form form={form} onFinish={handleFinish} layout='vertical'>
+          <Form.Item
+            name='title'
+            label='제목'
+            rules={[{ required: true, message: '제목을 입력해 주세요.' }]}
+          >
+            <Input
+              showCount
+              maxLength={26}
+              placeholder='제목을 입력해 주세요.'
+            />
+          </Form.Item>
+          <Form.Item
+            name='accompany_area'
+            label='동행 지역'
+            rules={[{ required: true, message: '동행 지역을 선택해 주세요.' }]}
+          >
+            <Select
+              showSearch
+              style={{ width: '100%' }}
+              placeholder='동행 지역을 선택해 주세요.'
+              optionFilterProp='label'
+              options={accompanyAreas.map((area) => ({
+                value: area,
+                label: area,
+              }))}
+            />
+          </Form.Item>
+          <Form.Item name='startDate' label='시작 날짜'>
+            <DatePicker style={{ width: '100%' }} format='YYYY-MM-DD' />
+          </Form.Item>
+          <Form.Item
+            name='endDate'
+            label='종료 날짜'
+            rules={[
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  const startDate = getFieldValue('startDate')
+                  if (value && startDate && value < startDate) {
+                    return Promise.reject(
+                      new Error('종료 날짜가 시작 날짜보다 빠를 수 없습니다.')
+                    )
+                  }
+                  return Promise.resolve()
+                },
+              }),
+            ]}
+          >
+            <DatePicker style={{ width: '100%' }} format='YYYY-MM-DD' />
+          </Form.Item>
+          <Form.Item
+            name='content'
+            label='내용'
+            rules={[{ required: true, message: '내용을 입력해 주세요.' }]}
+          >
+            <TextArea
+              showCount
+              maxLength={2000}
+              placeholder='내용을 입력해 주세요.'
+              style={{ height: 300, resize: 'none' }}
+            />
+          </Form.Item>
+          <Form.Item name='custom_url' label='커스텀 URL'>
+            <Input
+              addonBefore='https://'
+              placeholder='커스텀 URL을 입력해 주세요.'
+            />
+          </Form.Item>
+          <Form.Item>
+            <div className='flex justify-end gap-4'>
+              <Button type='default' onClick={() => form.resetFields()}>
+                게시글 초기화
+              </Button>
+              <Button type='primary' htmlType='submit'>
+                수정
+              </Button>
+            </div>
+          </Form.Item>
+        </Form>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/accompany/page.tsx
+++ b/src/app/(main)/accompany/page.tsx
@@ -1,23 +1,38 @@
 'use client'
-import { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { useDebouncedCallback } from 'use-debounce'
-import SearchIcon from '../../components/Icon/SearchIcon'
-import PostCard from '../../components/PostCard'
-import { mockData } from '../../data/mockData'
+import SearchIcon from '@/app/components/Icon/SearchIcon'
+import PostCard from '@/app/components/PostCard'
+import { mockData } from '@/app/data/mockData'
 import { UpCircleFilled } from '@ant-design/icons'
+import SuspenseWrapper from '@/app/components/SuspenseWrapper'
+import LoadingSpinner from '@/app/components/LoadingSpinner'
 
 export default function Home() {
+  // Next.js의 라우터 및 경로 관련 훅들
   const searchParams = useSearchParams()
   const pathname = usePathname()
   const router = useRouter()
   // URL에서 디코딩된 query 값을 가져옴
   const query = decodeURIComponent(searchParams.get('query') || '')
 
-  // 실시간으로 입력된 검색어를 상태로 관리
+  // 검색어 및 로딩 상태를 관리하는 상태 변수
   const [searchQuery, setSearchQuery] = useState(query)
+  const [loading, setLoading] = useState(true)
 
-  // 검색어가 변경될 때마다 URL 쿼리를 업데이트
+  // 컴포넌트가 마운트되었을 때 2초 동안 로딩 스피너를 보여줌
+  useEffect(() => {
+    // 2초의 지연 시간 설정
+    const timer = setTimeout(() => {
+      setLoading(false)
+    }, 2000)
+
+    // 컴포넌트가 언마운트될 때 타이머를 정리
+    return () => clearTimeout(timer)
+  }, [])
+
+  // 사용자가 검색어를 입력하면 URL 쿼리 파라미터를 업데이트하는 함수
   const handleSearch = useDebouncedCallback((term) => {
     const encodedTerm = encodeURIComponent(term)
     const params = new URLSearchParams(searchParams)
@@ -26,10 +41,11 @@ export default function Home() {
     } else {
       params.delete('query')
     }
+    // URL을 업데이트
     router.replace(`${pathname}?${params.toString()}`)
-  }, 300) // 300ms의 지연 시간
+  }, 300) // 300ms의 디바운스 적용
 
-  // 게시글 클릭 시 상세 페이지로 이동
+  // 게시글 카드를 클릭했을 때 해당 게시글의 상세 페이지로 이동
   const handleCardClick = (id: number) => {
     router.push(`/accompany/${id}`)
   }
@@ -39,57 +55,69 @@ export default function Home() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
+  // 로딩 중일 때 로딩 스피너를 표시
+  if (loading) {
+    return <LoadingSpinner />
+  }
+
   return (
-    <div className='w-full p-6'>
-      <div className='flex items-center justify-between mb-4'>
-        <h1 className='text-lg font-bold text-black'>동행 게시판</h1>
-      </div>
-
-      <div className='flex items-center mb-2 gap-2 h-[40px]'>
-        <div className='flex items-center w-full h-[40px] border-2 border-main p-2 rounded-full flex-grow box-sizing: border-box;'>
-          <SearchIcon />
-          <input
-            type='text'
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value)
-              handleSearch(e.target.value)
-            }}
-            placeholder='게시글 검색'
-            className='w-full pl-2 border-none outline-none text-sm '
-          />
+    // SuspenseWrapper를 사용하여 비동기 처리 시 로딩 스피너를 자동으로 보여줌
+    <SuspenseWrapper>
+      <div className='w-full p-6'>
+        {/* 페이지 헤더 */}
+        <div className='flex items-center justify-between mb-4'>
+          <h1 className='text-lg font-bold text-black'>동행 게시판</h1>
         </div>
-        <button
-          onClick={() => router.push('/accompany/create')}
-          className='bg-main text-white px-3 py-2 rounded-full flex-shrink-0 text-s h-[40px]'
-        >
-          게시글 등록 +
-        </button>
-      </div>
-      <button
-        className='fixed right-[10%] bottom-[10%] bg-white rounded-full cursor-pointer'
-        onClick={scrollToTop}
-      >
-        <UpCircleFilled style={{ color: 'var(--main)', fontSize: '30px' }} />
-      </button>
 
-      {/* 페이지 콘텐츠 */}
-      <div className='container mx-auto mt-4 mb-10'>
-        {mockData.map((post) => (
-          <div key={post.id} onClick={() => handleCardClick(post.id)}>
-            <PostCard
-              title={post.title}
-              content={post.content}
-              startDate={post.start_date}
-              endDate={post.end_date}
-              accompanyArea={post.accompany_area}
-              createdAt={post.created_at}
-              nickname={post.nickname}
-              profileImagePath={post.profile_image_path}
+        {/* 검색 바와 게시글 등록 버튼 */}
+        <div className='flex items-center mb-2 gap-2 h-[40px]'>
+          <div className='flex items-center w-full h-[40px] border-2 border-main p-2 rounded-full flex-grow'>
+            <SearchIcon />
+            <input
+              type='text'
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value)
+                handleSearch(e.target.value)
+              }}
+              placeholder='게시글 검색'
+              className='w-full pl-2 border-none outline-none text-sm'
             />
           </div>
-        ))}
+          <button
+            onClick={() => router.push('/accompany/create')}
+            className='bg-main text-white px-3 py-2 rounded-full flex-shrink-0 text-s h-[40px]'
+          >
+            게시글 등록 +
+          </button>
+        </div>
+
+        {/* 페이지 상단으로 이동 버튼 */}
+        <button
+          className='fixed right-[10%] bottom-[10%] bg-white rounded-full cursor-pointer'
+          onClick={scrollToTop}
+        >
+          <UpCircleFilled style={{ color: 'var(--main)', fontSize: '30px' }} />
+        </button>
+
+        {/* 게시글 리스트 */}
+        <div className='container mx-auto mt-4 mb-10'>
+          {mockData.map((post) => (
+            <div key={post.id} onClick={() => handleCardClick(post.id)}>
+              <PostCard
+                title={post.title}
+                content={post.content}
+                startDate={post.start_date}
+                endDate={post.end_date}
+                accompanyArea={post.accompany_area}
+                createdAt={post.created_at}
+                nickname={post.nickname}
+                profileImagePath={post.profile_image_path}
+              />
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </SuspenseWrapper>
   )
 }

--- a/src/app/components/ClientContent.tsx
+++ b/src/app/components/ClientContent.tsx
@@ -3,7 +3,6 @@
 import React from 'react'
 import Header from './Header'
 import BottomNav from './BottomNav'
-import SuspenseWrapper from './SuspenseWrapper'
 
 export default function ClientContent({
   children,
@@ -13,14 +12,12 @@ export default function ClientContent({
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <Header />
-      <SuspenseWrapper>
-        <main
-          style={{ flex: 1 }}
-          className='flex mt-[70px] justify-center items-start bg-white'
-        >
-          {children}
-        </main>
-      </SuspenseWrapper>
+      <main
+        style={{ flex: 1 }}
+        className='flex mt-[70px] justify-center items-start bg-white'
+      >
+        {children}
+      </main>
       <BottomNav />
     </div>
   )

--- a/src/app/components/ClientContent.tsx
+++ b/src/app/components/ClientContent.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import Header from './Header'
 import BottomNav from './BottomNav'
+import SuspenseWrapper from './SuspenseWrapper'
 
 export default function ClientContent({
   children,
@@ -12,12 +13,14 @@ export default function ClientContent({
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <Header />
-      <main
-        style={{ flex: 1 }}
-        className='flex mt-[70px] justify-center items-start bg-white'
-      >
-        {children}
-      </main>
+      <SuspenseWrapper>
+        <main
+          style={{ flex: 1 }}
+          className='flex mt-[70px] justify-center items-start bg-white'
+        >
+          {children}
+        </main>
+      </SuspenseWrapper>
       <BottomNav />
     </div>
   )

--- a/src/app/components/LoadingSpinner.tsx
+++ b/src/app/components/LoadingSpinner.tsx
@@ -1,0 +1,13 @@
+// components/LoadingSpinner.tsx
+
+import React from 'react'
+import { Spin } from 'antd'
+import { LoadingOutlined } from '@ant-design/icons'
+
+export default function LoadingSpinner() {
+  return (
+    <div className='flex justify-center items-center h-full'>
+      <Spin indicator={<LoadingOutlined style={{ fontSize: 48 }} spin />} />
+    </div>
+  )
+}

--- a/src/app/components/ShareModal.tsx
+++ b/src/app/components/ShareModal.tsx
@@ -1,14 +1,13 @@
-// components/ShareModal.tsx
-import { Modal, Input, Button } from 'antd'
+import { Modal, Button } from 'antd'
 import React from 'react'
-import { CopyOutlined } from '@ant-design/icons'
+import UrlInput from '@/app/components/UrlInput' // UrlInput 컴포넌트 임포트
 import { useCustomMessage } from '@/app/utils/alertUtils'
 import { usePathname } from 'next/navigation'
 
 interface ShareModalProps {
   isOpen: boolean
   onClose: () => void
-  customUrl?: string // 백엔드에서 전달된 커스텀 URL
+  customUrl?: string
   customUrlQrPath: string
 }
 
@@ -18,22 +17,9 @@ const ShareModal: React.FC<ShareModalProps> = ({
   customUrl,
   customUrlQrPath,
 }) => {
-  const { contextHolder, showSuccess, showError } = useCustomMessage()
-  const pathname = usePathname() // 현재 페이지의 경로를 가져옴
-  const defaultUrl = `https://example.com${pathname}` // 현재 페이지의 URL
-
-  // 복사 기능
-  const handleCopy = (url: string) => {
-    navigator.clipboard
-      .writeText(url)
-      .then(() => {
-        showSuccess('URL이 복사되었습니다.')
-      })
-      .catch((err) => {
-        showError('복사에 실패했습니다.')
-        console.error('Failed to copy: ', err)
-      })
-  }
+  const { contextHolder } = useCustomMessage()
+  const pathname = usePathname()
+  const defaultUrl = `https://example.com${pathname}`
 
   return (
     <>
@@ -52,42 +38,13 @@ const ShareModal: React.FC<ShareModalProps> = ({
       >
         <div className='text-center mb-5'>
           <div className='w-52 h-52 bg-gray-200 mx-auto flex items-center justify-center'>
-            {/* QR 코드 이미지 자리 */}
             <img src={customUrlQrPath} alt='QR Code' />
           </div>
         </div>
 
-        {/* 현재 페이지의 URL */}
-        <div className='mb-3'>
-          <Input
-            addonBefore='URL'
-            value={defaultUrl}
-            readOnly
-            suffix={
-              <CopyOutlined
-                onClick={() => handleCopy(defaultUrl)}
-                className='cursor-pointer'
-              />
-            }
-          />
-        </div>
+        <UrlInput label='URL' url={defaultUrl} />
 
-        {/* 커스텀 URL이 있는 경우에만 렌더링 */}
-        {customUrl && (
-          <div className='mb-3'>
-            <Input
-              addonBefore='커스텀 URL'
-              value={customUrl}
-              readOnly
-              suffix={
-                <CopyOutlined
-                  onClick={() => handleCopy(customUrl)}
-                  className='cursor-pointer'
-                />
-              }
-            />
-          </div>
-        )}
+        {customUrl && <UrlInput label='커스텀 URL' url={customUrl} />}
       </Modal>
     </>
   )

--- a/src/app/components/SuspenseWrapper.tsx
+++ b/src/app/components/SuspenseWrapper.tsx
@@ -1,0 +1,12 @@
+// components/SuspenseWrapper.tsx
+
+import React, { Suspense, ReactNode } from 'react'
+import LoadingSpinner from './LoadingSpinner'
+
+type SuspenseWrapperProps = {
+  children: ReactNode
+}
+
+export default function SuspenseWrapper({ children }: SuspenseWrapperProps) {
+  return <Suspense fallback={<LoadingSpinner />}>{children}</Suspense>
+}

--- a/src/app/components/UrlInput.tsx
+++ b/src/app/components/UrlInput.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Input } from 'antd'
+import { CopyOutlined } from '@ant-design/icons'
+import { copyToClipboard } from '@/app/utils/clipboardUtils'
+
+interface UrlInputProps {
+  label: string
+  url: string
+}
+
+const UrlInput: React.FC<UrlInputProps> = ({ label, url }) => (
+  <Input
+    addonBefore={label}
+    value={url}
+    readOnly
+    suffix={
+      <CopyOutlined
+        onClick={() => copyToClipboard(url)}
+        className='cursor-pointer'
+      />
+    }
+    className='mb-3'
+  />
+)
+
+export default UrlInput

--- a/src/app/utils/clipboardUtils.ts
+++ b/src/app/utils/clipboardUtils.ts
@@ -1,0 +1,11 @@
+import { message } from 'antd'
+
+export const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    message.success('URL이 복사되었습니다.')
+  } catch (err) {
+    message.error('복사에 실패했습니다.')
+    console.error('Failed to copy: ', err)
+  }
+}

--- a/src/app/utils/formUtils.ts
+++ b/src/app/utils/formUtils.ts
@@ -27,7 +27,16 @@ export function formatCustomUrl(customUrl?: string | null): string | null {
 }
 
 // 폼 데이터 처리 함수
-export function formatFormData(values: any) {
+interface FormValues {
+  title: string
+  accompany_area: string
+  startDate: dayjs.Dayjs | null
+  endDate: dayjs.Dayjs | null
+  content: string
+  custom_url?: string | null
+}
+
+export function formatFormData(values: FormValues) {
   const { title, accompany_area, startDate, endDate, content, custom_url } =
     values
 
@@ -36,7 +45,7 @@ export function formatFormData(values: any) {
     endDate
   )
 
-  const formattedData = {
+  return {
     title,
     accompany_area,
     content,
@@ -44,6 +53,4 @@ export function formatFormData(values: any) {
     end_date: formattedEndDate,
     custom_url: formatCustomUrl(custom_url),
   }
-
-  return formattedData
 }

--- a/src/app/utils/formUtils.ts
+++ b/src/app/utils/formUtils.ts
@@ -21,9 +21,10 @@ export function formatDates(
   return { formattedStartDate, formattedEndDate }
 }
 
-// 커스텀 URL 처리 함수
+// 커스텀 URL 처리 함수 (환경 변수 사용)
 export function formatCustomUrl(customUrl?: string | null): string | null {
-  return customUrl ? `https://ex.com/${customUrl}` : null
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
+  return customUrl ? `${baseUrl}/${customUrl}` : null
 }
 
 // 폼 데이터 처리 함수


### PR DESCRIPTION
## 📝 개요

- 동행 게시글 수정 페이지 레이아웃입니다.
- mockdata의 게시글 id와 연결하여 게시글 상세페이지에서 수정버튼을 클릭하면 해당 게시글의 내용을 수정할 수 있습니다.
- 게시글 작성페이지와 동일하게 유효성검사가 들어가고, 게시글 초기화버튼을 클릭하면 게시글 내 인풋값들이 모두 초기화됩니다.

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 수정페이지 레이아웃 구현 및 동적 라우팅 적용
  - ✨ 페이지 로딩 시 suspense loading 컴포넌트 출력 추가 (하단 이미지 확인)
  - ✨ 빌드에러 해결
    - 문제 : 로컬에서는 잘 돌아가지만, build 시 에러 메시지 출력
    - useSearchParams의 Suspense Boundary 
    -  문제 : useSearchParams() 훅은 React의 Suspense 컴포넌트 안에 포함되어야 하는데, 그렇지 않아서 오류가 발생했습니다. 이 훅은 클라이언트 측에서 실행되며, Next.js는 CSR(클라이언트 사이드 렌더링)로 사용되는 컴포넌트를 Suspense로 감싸야 합니다.
    - 해결 :  컴포넌트를 React의 내부에 래핑하려는 시도도 해봤으나 빌드에러가 해결되지 않아 nextConfig 파일에 아래와 같은 코드를 추가해주고 문제를 해결
    ```javascript
     const nextConfig = {
      experimental: {
      missingSuspenseWithCSRBailout: false,
    }
    ```
  - ✨ 이전 PR 리뷰 반영
    - 중복코드 컴포넌트, utils 함수로 분리
    - 커스텀 url에 들어갈 도메인 주소 환경변수로 별도 관리

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략))
  - 예: closes #10 

## 📸 스크린샷 (옵션) 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/68337f84-4b58-4a21-80f3-00b0fb21165d">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/85690b52-3dd2-4347-83b1-3072e82699ce">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/51b059c0-afa5-4457-8bae-47f74ce4b767">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b2fd16b2-eeed-4335-ae4c-3335c2201fa8">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/75caa9aa-e423-42a5-899f-f8af5c37ea1b">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4c17638c-775b-41b8-859e-1075f4ab7b8f">



## ℹ️ 참고 사항

- 빌드에러에 참고한 자료 : https://github.com/vercel/next.js/issues/61697