### PR TITLE
👷 github-actions fix - 깃허브 액션 build/ dev/ production 분리

### DIFF
--- a/.github/workflows/github-actions-build.yaml
+++ b/.github/workflows/github-actions-build.yaml
@@ -1,0 +1,26 @@
+name: Front-dev pull-request build start
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build Next.js app
+      run: npm run build
+

--- a/.github/workflows/github-actions-dev.yaml
+++ b/.github/workflows/github-actions-dev.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - dev
-      - main
-  pull_request:
-    branches:
-      - dev
-      - main
 
 jobs:
   build:
@@ -30,7 +25,7 @@ jobs:
       run: npm run build
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v3```
       with:
         registry: ghcr.io
         username: TopazKang
@@ -50,7 +45,7 @@ jobs:
       - name: SSH and Deploy Frontend
         uses: appleboy/ssh-action@v0.1.8
         with:
-          host: ${{ secrets.EC2_HOST }}
+          host: ${{ secrets.EC2_HOST_DEV }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.ARK_DEPLOY }}
           port: 22

--- a/.github/workflows/github-actions-prod.yaml
+++ b/.github/workflows/github-actions-prod.yaml
@@ -1,0 +1,57 @@
+name: Front-Prod build & deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build Next.js app
+      run: npm run build
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: TopazKang
+        password: ${{ secrets.GHCR_TOKEN }}
+
+    - name: Build Docker image
+      run: docker build -t ghcr.io/topazkang/fe-prod:latest .
+
+    - name: Push Docker image to GHCR
+      run: docker push ghcr.io/topazkang/fe-prod:latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: SSH and Deploy Frontend
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.EC2_HOST_PROD }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.ARK_DEPLOY }}
+          port: 22
+          script: |
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GIT_USER }} --password-stdin
+            cd deploy/conf
+            docker-compose -f docker-compose.front.yaml down
+            docker-compose -f docker-compose.front.yaml pull
+            docker-compose -f docker-compose.front.yaml up -d


### PR DESCRIPTION
### 🚀 이 PR을 통해 해결하려는 문제
> 이 PR을 통해 해결하려는 문제를 적어주세요
- [ 어떤 브랜치인지에 상관없이 pr을 요청하거나 merge 되는 순간 빌드 및 배포되던 기존의 github-actions.yaml을, 각각 build파일: dev 브랜치 pr 요청 시 프로젝트 빌드/ dev 파일: dev 브랜치 merge 시에 ec2 dev용 서버로 빌드 및 배포/ prod파일: main 브랜치 merge 시에 ec2 production 서버에 빌드 및 배포작업을 진행할 수 있게끔 부담을 나눠주기 위함. ]  

### ✨ 이 PR에서 핵심적으로 변경된 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요-->
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- github-actions.yaml => github-actions-build.yaml/ github-actions-dev.yaml/ github-actions-prod.yaml로 분리

### 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 ‘없음’ 이라고 기재해 주세요 -->
>없으면 ‘없음’ 이라고 기재해 주세요
- 없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 