### PR TITLE
🐛 fix: 이슈 #45 - 댓글 컴포넌트 PC뷰에서 넘치게 출력되는 부분 해결

### DIFF
--- a/src/app/(main)/accompany/[id]/page.tsx
+++ b/src/app/(main)/accompany/[id]/page.tsx
@@ -322,7 +322,7 @@ export default function AccompanyDetailPage() {
           ))}
         </div>
       </div>
-      <div className='px-4 py-2 fixed  w-full bg-white bottom-[60px] z-10'>
+      <div className='px-4 py-2 fixed  w-full md:w-[768px] bg-white bottom-[60px] z-10'>
         <div className='flex items-center'>
           <input
             type='text'


### PR DESCRIPTION
🐛 fix: 이슈 #45 - 댓글 컴포넌트 PC뷰에서 넘치게 출력되는 부분 해결

- PC뷰에서 댓글 컴포넌트의 레이아웃이 넘치는 문제 수정
- CSS 조정으로 PC 화면에서의 UI 정렬 개선

closes #45

## 📝 개요

- 이 PR의 목적과 관련된 정보를 간략히 설명합니다.

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 항목 1
  - ✨ 항목 2
  - ✨ 항목 3

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략)
  - closes #45

## 📸 스크린샷 (옵션)

- UI 변경 사항이 있는 경우 스크린샷을 포함합니다.
변경전 / 변경후 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ca4454c7-0491-48d7-aa30-90f6ff96dbe5">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ad099f52-760d-467b-9f46-7c4072fc4756">

## ℹ️ 참고 사항

- 커밋명 잘못나갔습니다. PR 내용으로 봐주시면 됩니다.
