### PR TITLE
👷 github-actions 안쓰는 도커 이미지 제거 구문 추가

### DIFF
--- a/.github/workflows/github-actions-dev.yaml
+++ b/.github/workflows/github-actions-dev.yaml
@@ -74,6 +74,7 @@ jobs:
             echo "${{ secrets.ENV_FILE_DEV }}" > deploy/front/.env
             echo "${{ secrets.GHCR_TOKEN }}" | sudo docker login ghcr.io -u ${{ secrets.GIT_USER }} --password-stdin
             cd deploy/front
+            sudo docker image prune -a -f
             sudo docker-compose -f docker-compose.front.yaml down
             sudo docker-compose -f docker-compose.front.yaml pull
             sudo docker-compose -f docker-compose.front.yaml up -d

--- a/.github/workflows/github-actions-prod.yaml
+++ b/.github/workflows/github-actions-prod.yaml
@@ -70,6 +70,7 @@ jobs:
             echo "${{ secrets.ENV_FILE_PROD }}" > deploy/front/.env
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GIT_USER }} --password-stdin
             cd deploy/front
+            docker image prune -a -f
             docker-compose -f docker-compose.front.yaml down
             docker-compose -f docker-compose.front.yaml pull
             docker-compose -f docker-compose.front.yaml up -d


### PR DESCRIPTION
## 📝 개요

- 사용이 끝난 도커 이미지들이 스토리지 용량을 차지함에 따라 새로운 이미지를 pull 해오는 과정에 문제가 생김.

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ github-actions yaml파일에 docker image prune 구문을 추가

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략)
  - 예: closes #123, resolves #456

## 📸 스크린샷 (옵션)

- UI 변경 사항이 있는 경우 스크린샷을 포함합니다.

## ℹ️ 참고 사항

- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함합니다.
