### PR TITLE
Feature/chat 채팅방 로직 구현 API 연결완료, 채팅방 입장/퇴장 메시징 처리, 하단 자동스크롤 로직

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.0.1",
         "@sentry/nextjs": "^8.26.0",
+        "@stomp/stompjs": "^7.0.0",
         "antd": "^5.20.1",
         "cookies-next": "^4.2.1",
         "date-fns": "^3.6.0",
@@ -19,6 +20,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-kakao-maps-sdk": "^1.1.27",
+        "sockjs-client": "^1.6.1",
         "use-debounce": "^10.0.2",
         "zustand": "^4.5.5"
       },
@@ -26,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/sockjs-client": "^1.5.4",
         "@typescript-eslint/eslint-plugin": "^8.0.1",
         "@typescript-eslint/parser": "^8.0.1",
         "babel-plugin-import": "^1.13.8",
@@ -2095,6 +2098,11 @@
         "webpack": ">=4.40.0"
       }
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw=="
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2221,6 +2229,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.0.1",
@@ -4471,6 +4485,14 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4528,6 +4550,17 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4934,6 +4967,11 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -5029,8 +5067,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -6806,6 +6843,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7526,6 +7568,11 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -7707,8 +7754,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -7884,6 +7930,32 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map": {
@@ -8630,6 +8702,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-debounce": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.2.tgz",
@@ -8773,6 +8854,27 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.0.1",
     "@sentry/nextjs": "^8.26.0",
+    "@stomp/stompjs": "^7.0.0",
     "antd": "^5.20.1",
     "cookies-next": "^4.2.1",
     "date-fns": "^3.6.0",
@@ -20,6 +21,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-kakao-maps-sdk": "^1.1.27",
+    "sockjs-client": "^1.6.1",
     "use-debounce": "^10.0.2",
     "zustand": "^4.5.5"
   },
@@ -27,6 +29,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/sockjs-client": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "babel-plugin-import": "^1.13.8",

--- a/src/app/(main)/chat/[id]/page.tsx
+++ b/src/app/(main)/chat/[id]/page.tsx
@@ -1,164 +1,113 @@
 'use client'
 
-import React, { useEffect, useRef, useState } from 'react'
-import MyChatContainer from '@/app/components/chat/MyChatContainer'
-import LeftChatContainer from '@/app/components/chat/LeftChatContainer'
-import DateSeparator from '@/app/components/chat/DateSeperator'
-import { format } from 'date-fns'
-import { ko } from 'date-fns/locale'
-import { checkChatRoomEntry } from '@/app/utils/fetchUtils'
+import React, { useEffect, useRef, useState, useLayoutEffect } from 'react'
+import { checkChatRoomEntry, getPreviousMessages } from '@/app/utils/fetchUtils'
 import { useCustomMessage } from '@/app/utils/alertUtils'
 import { useRouter, usePathname } from 'next/navigation'
-import { ChatRoomEntryData } from '@/interfaces/index'
-import MenuDrawer from '@/app/components/chat/MenuDrawer'
-import LoadingSpinner from '@/app/components/common/LoadingSpinner' // 로딩 스피너 컴포넌트 추가
-import { LeftOutlined } from '@ant-design/icons'
+import LoadingSpinner from '@/app/components/common/LoadingSpinner'
+import { Client, IMessage } from '@stomp/stompjs'
+import SockJS from 'sockjs-client'
+import useAuthStore from '@/app/store/useAuthStore'
+import ChatHeader from '@/app/components/chat/ChatHeader'
+import MessageList from '@/app/components/chat/MessageList'
+import ChatInput from '@/app/components/chat/ChatInput'
+import { ChatRoomEntryData, Message } from '@/interfaces/index'
 
-// 예시 데이터
-const messages = [
-  {
-    id: '66bf09f471faff02a7e52525',
-    roomId: 1,
-    senderId: 1,
-    message: '안녕하세요!',
-    createdAt: '2024-08-16T17:12:36',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-  {
-    id: '66bf09fd71faff02a7e52526',
-    roomId: 1,
-    senderId: 2,
-    message: '반가워요!',
-    createdAt: '2024-08-16T17:14:22',
-    nickname: '유리',
-    profileImagePath: 'https://example.com/profiles/user2.png',
-  },
-  {
-    id: '66bf0a0171faff02a7e52527',
-    roomId: 1,
-    senderId: 1,
-    message:
-      '오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요. 오늘 날씨 정말 좋네요.',
-    createdAt: '2024-08-16T17:15:30',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-  {
-    id: '66bf0a0571faff02a7e52528',
-    roomId: 1,
-    senderId: 2,
-    message: '그러게요! 산책하기 딱 좋은 날씨예요.',
-    createdAt: '2024-08-16T17:16:45',
-    nickname: '유리',
-    profileImagePath: 'https://example.com/profiles/user2.png',
-  },
-  {
-    id: '66bf0a0b71faff02a7e52529',
-    roomId: 1,
-    senderId: 1,
-    message: '산책 같이 가실래요?',
-    createdAt: '2024-08-17T17:18:00',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-  {
-    id: '66bf0a1271faff02a7e52530',
-    roomId: 1,
-    senderId: 2,
-    message:
-      '좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요? 좋아요! 어디서 만날까요?',
-    createdAt: '2024-08-18T17:19:10',
-    nickname: '유리',
-    profileImagePath: 'https://example.com/profiles/user2.png',
-  },
-  {
-    id: '66bf0a1771faff02a7e52531',
-    roomId: 1,
-    senderId: 1,
-    message:
-      '저희 동네 근처 공원 어때요? 저희 동네 근처 공원에서 만나는 건 어떤가요? 공원이 넓고 예뻐서 산책하기 좋을 것 같아요. 평소에도 자주 산책하곤 하는데, 이번에는 같이 가면 좋을 것 같아요!',
-    createdAt: '2024-08-18T17:20:45',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-  {
-    id: '66bf0a1c71faff02a7e52532',
-    roomId: 1,
-    senderId: 2,
-    message:
-      '좋아요! 저도 공원 가는 거 좋아해요. 그럼 몇 시쯤 만날까요? 아침이나 저녁이 좋을 것 같은데, 세니님은 언제가 편하세요? 저는 오후에 시간이 조금 애매해서 아침이나 저녁이 더 좋을 것 같아요!',
-    createdAt: '2024-08-18T17:21:55',
-    nickname: '유리',
-    profileImagePath: 'https://example.com/profiles/user2.png',
-  },
-  {
-    id: '66bf0a2171faff02a7e52533',
-    roomId: 1,
-    senderId: 1,
-    message:
-      '저도 저녁이 좋을 것 같아요! 해질 무렵에 공원에서 만나서 산책하면서 얘기 나누면 좋을 것 같아요. 그때쯤 바람도 시원하게 불고 분위기도 좋을 것 같아요. 저녁 6시쯤 어떠세요?',
-    createdAt: '2024-08-18T17:23:30',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-  {
-    id: '66bf0a2171faff02a7e52537',
-    roomId: 1,
-    senderId: 1,
-    message:
-      ' 바람도 시원하게 불고 분위기도 좋을 것 같아요. 저녁 6시쯤 어떠세요?',
-    createdAt: '2024-08-18T17:23:30',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-  {
-    id: '66bf0a2671faff02a7e52534',
-    roomId: 1,
-    senderId: 2,
-    message:
-      '네! 6시 좋아요. 그럼 공원 입구에서 만날까요? 저는 집에서 가깝기도 하고, 거기서부터 산책로가 시작되니까 딱 좋을 것 같아요. 그리고 날씨만 좋으면 아주 기분 좋은 시간이 될 것 같네요!',
-    createdAt: '2024-08-18T17:25:00',
-    nickname: '유리',
-    profileImagePath: 'https://example.com/profiles/user2.png',
-  },
-  {
-    id: '66bf0a2b71faff02a7e52535',
-    roomId: 1,
-    senderId: 1,
-    message:
-      '좋아요! 그럼 내일 6시에 공원 입구에서 봬요. 즐거운 시간 보내요! 😊',
-    createdAt: '2024-08-18T17:26:20',
-    nickname: '세니',
-    profileImagePath: 'https://example.com/profiles/user1.png',
-  },
-]
-
-// 오전/오후 형식으로 시간 변환
-function formatWithMeridiem(date: Date) {
-  const hours = date.getHours()
-  const meridiem = hours < 12 ? '오전' : '오후'
-  return `${meridiem} ${format(date, 'h:mm', { locale: ko })}`
-}
-
-export default function GroupDetailPage() {
+export default function ChatDetailPage() {
   const [chatRoomData, setChatRoomData] = useState<ChatRoomEntryData | null>(
     null
   )
   const [loading, setLoading] = useState(true) // 로딩 상태 추가
   const { contextHolder, showWarning } = useCustomMessage()
-  let lastDate = '' // 마지막으로 표시된 날짜를 저장
-  const bottomRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
   const path = usePathname()
   const chatRoomId = parseInt(path.split('/').pop() || '0', 10)
   const [isMember, setIsMember] = useState<boolean>(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  // 메시지 리스트
+  const [messages, setMessages] = useState<Message[]>([])
+  // 입력된 메시지 상태
+  const [content, setContent] = useState<string>('')
+  // 메시지 리스트의 끝을 참조
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  // STOMP 클라이언트 참조
+  const clientRef = useRef<Client | null>(null)
+  const { userId } = useAuthStore()
+
+  // 메시지가 업데이트된 후 실행되는 스크롤 함수
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'auto' })
+  }
 
   useEffect(() => {
-    // 페이지 로드 시 맨 아래로 스크롤
-    bottomRef.current?.scrollIntoView({ behavior: 'auto' })
-  }, [])
+    if (!loading) {
+      scrollToBottom()
+    }
+  }, [messages, loading])
+
+  // 이전 메시지를 불러오는 함수
+  const fetchMessages = async () => {
+    try {
+      const messages = await getPreviousMessages(chatRoomId)
+      setMessages(messages) // 가져온 메시지를 상태에 저장
+    } catch (error) {
+      console.error('Failed to load messages:', error)
+    }
+  }
+
+  // 메시지 전송 함수
+  const SendMessage = () => {
+    if (content.trim() && clientRef.current?.connected) {
+      clientRef.current.publish({
+        destination: `/pub/chat/room/${chatRoomId}`,
+        body: JSON.stringify({
+          chatRoomId: chatRoomId,
+          senderId: userId,
+          content: content,
+        }),
+      })
+      console.log('Message sent:', content)
+      setContent('') // 메시지 전송 후 입력 필드를 초기화
+    }
+  }
+
+  useEffect(() => {
+    // 이전 메시지 로드
+    fetchMessages()
+
+    const socket = new SockJS(`${process.env.NEXT_PUBLIC_SERVER_URL}/ws/init`)
+    const client = new Client({
+      webSocketFactory: () => socket as WebSocket,
+      onConnect: () => {
+        if (!client || !chatRoomId) return
+        client.subscribe(
+          `/sub/chat/room/${chatRoomId}`,
+          (message: IMessage) => {
+            console.log('subscribe 되면 콘솔 찍어줄게요!')
+            const body = JSON.parse(message.body)
+            if (body) {
+              console.log(body.id)
+              setMessages((prevMessages) => [...prevMessages, body])
+            }
+          }
+        )
+      },
+      onStompError: (error) => {
+        console.error('STOMP error:', error)
+      },
+    })
+
+    // WebSocket 연결 활성화
+    client.activate()
+    clientRef.current = client
+
+    return () => {
+      if (clientRef.current) {
+        // 컴포넌트가 언마운트될 때 WebSocket 연결 비활성화
+        clientRef.current.deactivate()
+      }
+    }
+  }, [chatRoomId])
 
   useEffect(() => {
     const fetchChatRoomData = async () => {
@@ -193,7 +142,6 @@ export default function GroupDetailPage() {
     }
   }, [errorMessage, showWarning, router])
 
-  // 데이터 페칭 중일 때 로딩 스피너를 표시
   if (loading) {
     return (
       <div className='flex justify-center items-center h-screen'>
@@ -207,62 +155,15 @@ export default function GroupDetailPage() {
       {contextHolder}
       {isMember && (
         <div>
-          <div className='fixed top-0 left-1/2 transform -translate-x-1/2 w-full max-w-[500px] h-12 bg-white shadow-md z-10'>
-            <div className='w-full h-full flex items-center justify-between p-4'>
-              <div
-                onClick={() => router.back()}
-                className='text-sm cursor-pointer text-secondary hover:text-black'
-              >
-                <LeftOutlined style={{ fontSize: 20 }} />
-              </div>
-              {/* Menu Drawer Component */}
-              {chatRoomData && <MenuDrawer chatRoomData={chatRoomData} />}
-            </div>
-          </div>
+          <ChatHeader chatRoomData={chatRoomData} />
           <div className='bg-white w-full h-full mb-[110px] mt-[-20px]'>
-            {messages.map((msg) => {
-              const currentDate = format(new Date(msg.createdAt), 'yyyy-MM-dd')
-              const showDateSeparator = currentDate !== lastDate
-              lastDate = currentDate
-
-              return (
-                <div
-                  key={msg.id}
-                  className='flex flex-col w-full px-4 py-1 items-center justify-center'
-                >
-                  {/* 날짜 구분선을 표시 */}
-                  {showDateSeparator && <DateSeparator date={msg.createdAt} />}
-                  {/* 채팅 메시지 표시 */}
-                  {msg.senderId === 1 ? (
-                    <MyChatContainer
-                      message={msg.message}
-                      time={formatWithMeridiem(new Date(msg.createdAt))}
-                    />
-                  ) : (
-                    <LeftChatContainer
-                      message={msg.message}
-                      time={formatWithMeridiem(new Date(msg.createdAt))}
-                      nickname='세니'
-                      profileSrc=''
-                    />
-                  )}
-                </div>
-              )
-            })}
-            {/* 스크롤이 이동할 위치 */}
-            <div ref={bottomRef}></div>
-            <div className='px-4 py-2 fixed w-full max-w-[500px] bg-white bottom-[60px] z-10'>
-              <div className='flex items-center w-full'>
-                <input
-                  type='text'
-                  placeholder='메시지를 입력하세요.'
-                  className='flex-1 w-full h-[35px] p-2 px-4 border border-gray-300 rounded-full focus:border-sub focus:border-2 outline-none'
-                />
-                <button className='ml-3 h-[35px] bg-sub text-white py-0 px-5 rounded-full text-sm whitespace-nowrap'>
-                  전송
-                </button>
-              </div>
-            </div>
+            <MessageList messages={messages} userId={userId || ''} />
+            <div ref={messagesEndRef}></div>
+            <ChatInput
+              content={content}
+              setContent={setContent}
+              onSendMessage={SendMessage}
+            />
           </div>
         </div>
       )}

--- a/src/app/(main)/community/create/page.tsx
+++ b/src/app/(main)/community/create/page.tsx
@@ -1,0 +1,37 @@
+// pages/accompany/create/page.tsx
+'use client'
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { useCustomMessage } from '@/app/utils/alertUtils'
+import { formatCommunityFormData } from '@/app/utils/formUtils'
+import { api } from '@/app/utils/api'
+import { CommunityFormValues } from '@/interfaces'
+import CommunityForm from '@/app/components/community/CommunityForm'
+
+export default function CreateAccompanyPage() {
+  const router = useRouter()
+  const { contextHolder, showSuccess, showError } = useCustomMessage()
+
+  const handleFinish = async (values: CommunityFormValues) => {
+    try {
+      const formData = formatCommunityFormData(values)
+      await api.post(`/api/v1/community/posts`, formData)
+      showSuccess('게시글 작성이 완료되었습니다.')
+      setTimeout(() => {
+        router.push('/community')
+      }, 1000)
+    } catch (error) {
+      console.error('Error occurred while creating post:', error)
+      showError('게시글 작성에 실패했습니다.')
+    }
+  }
+
+  return (
+    <div className='w-full p-6 mb-4'>
+      {contextHolder}
+      <h1 className='text-lg font-bold text-black'>커뮤니티 게시글 작성</h1>
+      <CommunityForm onSubmit={handleFinish} submitText='작성' />
+    </div>
+  )
+}

--- a/src/app/components/accompany/SearchBar.tsx
+++ b/src/app/components/accompany/SearchBar.tsx
@@ -27,6 +27,14 @@ const SearchBar: React.FC<SearchBarProps> = ({
     router.replace(`${pathname}?${params.toString()}`)
   }, 300)
 
+  const handleCreateButtonClick = () => {
+    if (pathname === '/accompany') {
+      router.push('/accompany/create')
+    } else if (pathname === '/community') {
+      router.push('/community/create')
+    }
+  }
+
   return (
     <div className='flex items-center mb-2 gap-2 h-[40px]'>
       <div className='flex items-center w-full h-[40px] border border-main p-2 rounded-full flex-grow'>
@@ -43,7 +51,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         />
       </div>
       <button
-        onClick={() => router.push('/accompany/create')}
+        onClick={handleCreateButtonClick}
         className='bg-main text-white px-3 py-2 rounded-full flex-shrink-0 text-s h-[40px]'
       >
         게시글 등록 +

--- a/src/app/components/chat/ChatHeader.tsx
+++ b/src/app/components/chat/ChatHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { LeftOutlined } from '@ant-design/icons'
+import MenuDrawer from '@/app/components/chat/MenuDrawer'
+import { useRouter } from 'next/navigation'
+import { ChatRoomEntryData } from '@/interfaces/index'
+
+interface ChatHeaderProps {
+  chatRoomData: ChatRoomEntryData | null
+}
+
+const ChatHeader: React.FC<ChatHeaderProps> = ({ chatRoomData }) => {
+  const router = useRouter()
+
+  return (
+    <div className='fixed top-0 left-1/2 transform -translate-x-1/2 w-full max-w-[500px] h-12 bg-white shadow-md z-10'>
+      <div className='w-full h-full flex items-center justify-between p-4'>
+        <div
+          onClick={() => router.back()}
+          className='text-sm cursor-pointer text-secondary hover:text-black'
+        >
+          <LeftOutlined style={{ fontSize: 20 }} />
+        </div>
+        {chatRoomData && <MenuDrawer chatRoomData={chatRoomData} />}
+      </div>
+    </div>
+  )
+}
+
+export default ChatHeader

--- a/src/app/components/chat/ChatInput.tsx
+++ b/src/app/components/chat/ChatInput.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+interface ChatInputProps {
+  content: string
+  setContent: (value: string) => void
+  onSendMessage: () => void
+}
+
+const ChatInput: React.FC<ChatInputProps> = ({
+  content,
+  setContent,
+  onSendMessage,
+}) => {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSendMessage()
+  }
+
+  return (
+    <div className='px-4 py-2 fixed w-full max-w-[500px] bg-white bottom-[60px] z-10'>
+      <form className='flex items-center w-full' onSubmit={handleSubmit}>
+        <input
+          type='text'
+          placeholder='메시지를 입력하세요.'
+          className='flex-1 w-full h-[35px] p-2 px-4 border border-gray-300 rounded-full focus:border-sub focus:border-2 outline-none'
+          value={content}
+          onChange={(e) => setContent(e.target.value)} // 입력된 값을 상태로 업데이트
+        />
+        <button
+          type='submit'
+          className='ml-3 h-[35px] bg-sub text-white py-0 px-5 rounded-full text-sm whitespace-nowrap'
+        >
+          전송
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default ChatInput

--- a/src/app/components/chat/GuestContent.tsx
+++ b/src/app/components/chat/GuestContent.tsx
@@ -159,6 +159,7 @@ const GuestContent: React.FC<GuestContentProps> = ({
           chatRoomId: chatRoomId,
           senderId: userId,
           content: `${nickname}님이 방에서 나가셨습니다.`,
+          infoFlag: true,
         }),
       })
       console.log('Leave message sent')

--- a/src/app/components/chat/LeftChatContainer.tsx
+++ b/src/app/components/chat/LeftChatContainer.tsx
@@ -1,28 +1,31 @@
 // components/chat/LeftChatContainer.tsx
 import React from 'react'
 import ProfileIcon from '@/app/components/common/ProfileIcon'
+import { profile } from 'console'
 
 interface LeftChatContainerProps {
   message: string
   time: string
-  nickname: string
+  senderNickname: string
   profileSrc: string
 }
 
 const LeftChatContainer: React.FC<LeftChatContainerProps> = ({
   message,
   time,
-  nickname,
+  senderNickname,
   profileSrc,
 }) => {
   return (
     <div className='flex w-full items-start justify-start gap-1 mt-2 pr-4'>
       <div className='items-center justify-center'>
-        <ProfileIcon src={profileSrc} size={33} nickname={nickname} />
+        <ProfileIcon src={profileSrc} size={33} nickname={senderNickname} />
       </div>
       <div className='flex gap-2'>
         <div className=''>
-          <div className='text-s font-medium text-gray-700'>{nickname}</div>
+          <div className='text-s font-medium text-gray-700'>
+            {senderNickname}
+          </div>
           <div className='flex items-center justify-between px-4 py-2 bg-gray-100 rounded-3xl text-sm'>
             {message}
           </div>

--- a/src/app/components/chat/MessageList.tsx
+++ b/src/app/components/chat/MessageList.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import MyChatContainer from '@/app/components/chat/MyChatContainer'
+import LeftChatContainer from '@/app/components/chat/LeftChatContainer'
+import DateSeparator from '@/app/components/chat/DateSeperator'
+import { format } from 'date-fns'
+import { ko } from 'date-fns/locale'
+import { Message } from '@/interfaces/index'
+
+interface MessageListProps {
+  messages: Message[]
+  userId: string
+}
+
+function formatWithMeridiem(date: Date) {
+  const hours = date.getHours()
+  const meridiem = hours < 12 ? '오전' : '오후'
+  return `${meridiem} ${format(date, 'h:mm', { locale: ko })}`
+}
+
+// 재렌더링 최적화를 위해 React.memo로 감싸기
+const MessageList: React.FC<MessageListProps> = React.memo(
+  ({ messages, userId }) => {
+    let lastDate = ''
+    return (
+      <>
+        {messages.map((msg) => {
+          const currentDate = format(new Date(msg.createdAt), 'yyyy-MM-dd')
+          const showDateSeparator = currentDate !== lastDate
+          lastDate = currentDate
+
+          // "00님이 방에서 나가셨습니다." 메시지를 처리하는 부분
+          const isLeaveMessage =
+            msg.content.includes('님이 방에서 나가셨습니다.')
+
+          return (
+            <div
+              key={msg.id}
+              className='flex flex-col w-full px-4 py-1 items-center justify-center'
+            >
+              {/* 날짜 구분선을 표시 */}
+              {showDateSeparator && <DateSeparator date={msg.createdAt} />}
+              {/* 채팅 메시지 표시 */}
+              {/* TODO: 00님이 방에서 나가셨습니다라는 메시지로만 구분해서 하지 말도록 로직 나중에 변경 필요  */}
+              {isLeaveMessage ? (
+                <div className='flex items-center justify-center gap-1 text-xs text-white bg-[rgba(0,0,0,0.2)] p-1 px-2 rounded-full my-2 mt-3'>
+                  {msg.content}
+                </div>
+              ) : msg.senderId == userId ? (
+                <MyChatContainer
+                  message={msg.content}
+                  time={formatWithMeridiem(new Date(msg.createdAt))}
+                />
+              ) : (
+                <LeftChatContainer
+                  message={msg.content}
+                  time={formatWithMeridiem(new Date(msg.createdAt))}
+                  senderNickname={msg.senderNickname}
+                  profileSrc={msg.senderProfileImage}
+                />
+              )}
+            </div>
+          )
+        })}
+      </>
+    )
+  }
+)
+
+export default MessageList

--- a/src/app/components/chat/MessageList.tsx
+++ b/src/app/components/chat/MessageList.tsx
@@ -40,8 +40,7 @@ const MessageList: React.FC<MessageListProps> = React.memo(
               {/* 날짜 구분선을 표시 */}
               {showDateSeparator && <DateSeparator date={msg.createdAt} />}
               {/* 채팅 메시지 표시 */}
-              {/* TODO: 00님이 방에서 나가셨습니다라는 메시지로만 구분해서 하지 말도록 로직 나중에 변경 필요  */}
-              {isLeaveMessage ? (
+              {msg.infoFlag ? (
                 <div className='flex items-center justify-center gap-1 text-xs text-white bg-[rgba(0,0,0,0.2)] p-1 px-2 rounded-full my-2 mt-3'>
                   {msg.content}
                 </div>

--- a/src/app/components/community/CommunityForm.tsx
+++ b/src/app/components/community/CommunityForm.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Input, Form, Button } from 'antd'
+
+const { TextArea } = Input
+
+interface CommunityFormProps {
+  initialValues?: {
+    title: string
+    content: string
+  }
+  onSubmit: (values: { title: string; content: string }) => void
+  submitText: string
+}
+
+export default function CommunityForm({
+  initialValues,
+  onSubmit,
+  submitText,
+}: CommunityFormProps) {
+  const [form] = Form.useForm()
+
+  return (
+    <Form
+      form={form}
+      initialValues={initialValues}
+      onFinish={onSubmit}
+      layout='vertical'
+    >
+      <Form.Item
+        name='title'
+        label='제목'
+        rules={[{ required: true, message: '제목을 입력해 주세요.' }]}
+      >
+        <Input showCount maxLength={26} placeholder='제목을 입력해 주세요.' />
+      </Form.Item>
+
+      <Form.Item
+        name='content'
+        label='내용'
+        rules={[{ required: true, message: '내용을 입력해 주세요.' }]}
+      >
+        <TextArea
+          showCount
+          maxLength={2000}
+          placeholder='내용을 입력해 주세요.'
+          style={{ height: 300, resize: 'none' }}
+        />
+      </Form.Item>
+
+      <Form.Item>
+        <div className='flex justify-end gap-4'>
+          <Button type='default' onClick={() => form.resetFields()}>
+            초기화
+          </Button>
+          <Button type='primary' htmlType='submit'>
+            {submitText}
+          </Button>
+        </div>
+      </Form.Item>
+    </Form>
+  )
+}

--- a/src/app/utils/fetchUtils.ts
+++ b/src/app/utils/fetchUtils.ts
@@ -239,3 +239,14 @@ export const updatePostStatus = async (postId: number) => {
     throw new Error('게시글 상태 변경에 실패했습니다.')
   }
 }
+
+// 채팅방의 이전 메시지를 가져오는 유틸리티 함수
+export const getPreviousMessages = async (chatRoomId: number) => {
+  try {
+    const response = await api.get(`/api/v1/chatRoom/${chatRoomId}/messages`)
+    return response // 이전 메시지를 반환
+  } catch (error) {
+    console.error('Failed to fetch previous messages:', error)
+    throw new Error('이전 메시지를 불러오는 데 실패했습니다.')
+  }
+}

--- a/src/app/utils/formUtils.ts
+++ b/src/app/utils/formUtils.ts
@@ -1,4 +1,5 @@
 // antd의 DatePicker 컴포넌트가 dayjs 기반
+import { CommunityFormValues, FormValues } from '@/interfaces'
 import dayjs from 'dayjs'
 
 // 날짜 처리 함수
@@ -24,14 +25,6 @@ export function formatDates(
 }
 
 // 폼 데이터 처리 함수
-interface FormValues {
-  title: string
-  accompanyArea: string
-  startDate: dayjs.Dayjs | null
-  endDate: dayjs.Dayjs | null
-  content: string
-}
-
 export function formatFormData(values: FormValues) {
   const { title, accompanyArea, startDate, endDate, content } = values
 
@@ -46,5 +39,15 @@ export function formatFormData(values: FormValues) {
     content,
     startDate: formattedStartDate,
     endDate: formattedEndDate,
+  }
+}
+
+// 커뮤니티 폼 데이터 처리 함수
+export function formatCommunityFormData(values: CommunityFormValues) {
+  const { title, content } = values
+
+  return {
+    title,
+    content,
   }
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -158,4 +158,5 @@ export interface Message {
   createdAt: string
   senderNickname: string
   senderProfileImage: string
+  infoFlag: boolean
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -93,6 +93,12 @@ export interface FormValues {
   content: string
 }
 
+// 커뮤니티 초기값 인터페이스
+export interface CommunityFormValues {
+  title: string
+  content: string
+}
+
 // AccompanyForm 컴포넌트에 전달되는 props 인터페이스
 export interface AccompanyFormProps {
   initialValues: FormValues
@@ -141,4 +147,15 @@ export interface ChatRoomEntryData {
   leaderId: number
   status: RecruitmentStatus
   isPostDeleted: boolean
+}
+
+// ChatMessage 인터페이스 정의
+export interface Message {
+  id: string
+  chatRoomId: number
+  senderId: string
+  content: string
+  createdAt: string
+  senderNickname: string
+  senderProfileImage: string
 }


### PR DESCRIPTION
## 📝 개요

- 채팅방 API 연결 완료하였습니다. stomp, SockJs 사용
- 이전메시지 fetch, 웹소켓 연결 활성화, 구독, 전송 기능
- 채팅방 입장/퇴장 시 채팅방에 메시지 노출
- 날짜 별 첫번째 메시지 상단에 현재 날짜 노출
- 엔터 클릭시 메시지 전송
- 채팅방 참여 멤버가 아닌경우, /chat으로 리다이렉트

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 항목 1
  - ✨ 항목 2
  - ✨ 항목 3

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략)
  - 예: closes #123, resolves #456

## 📸 스크린샷 (옵션)

- UI 변경 사항이 있는 경우 스크린샷을 포함합니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/340d14de-6b58-4306-9dbb-f88ec769dcd6">

## ℹ️ 참고 사항

- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함합니다.
