### PR TITLE
HotFix: 로고 이미지 깨짐 이슈, 동행게시글 수정페이지에서 날짜 표기 이슈 등 해결 + 기타 로직 추가

### DIFF
--- a/src/app/(main)/accompany/edit/[id]/page.tsx
+++ b/src/app/(main)/accompany/edit/[id]/page.tsx
@@ -5,10 +5,13 @@ import React, { useEffect, useState } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useCustomMessage } from '@/app/utils/alertUtils'
 import AccompanyForm from '@/app/components/accompany/AccompanyForm'
-import { fetchPost, updatePost } from '@/app/utils/fetchUtils'
+import { fetchEditPost, updatePost } from '@/app/utils/fetchUtils'
 import { formatFormData } from '@/app/utils/formUtils'
 import dayjs from 'dayjs'
-import { FormValues, Post } from '@/interfaces'
+import utc from 'dayjs/plugin/utc' // UTC 플러그인 추가
+import { EditPost, FormValues } from '@/interfaces'
+
+dayjs.extend(utc) // dayjs에서 UTC 사용하도록 설정
 
 export default function EditAccompanyPage() {
   const [initialValues, setInitialValues] = useState<FormValues | null>(null)
@@ -19,7 +22,8 @@ export default function EditAccompanyPage() {
   useEffect(() => {
     const loadPostData = async () => {
       try {
-        const post: Post = await fetchPost(parseInt(id as string, 10))
+        const response = await fetchEditPost(parseInt(id as string, 10)) // id를 숫자로 변환
+        const post: EditPost = response.data // Assign the correct type to the post variable
         if (post) {
           setInitialValues({
             title: post.title,

--- a/src/app/components/accompany/AccompanyForm.tsx
+++ b/src/app/components/accompany/AccompanyForm.tsx
@@ -31,6 +31,20 @@ export default function AccompanyForm({
 }: AccompanyFormProps) {
   const [form] = Form.useForm()
 
+  // 현재 날짜 이전을 비활성화하는 함수
+  const disablePastDates = (current: dayjs.Dayjs) => {
+    return current && current < dayjs().startOf('day')
+  }
+
+  // 종료 날짜에서 시작 날짜 이후만 선택 가능하도록 설정하는 함수
+  const disableEndDate = (current: dayjs.Dayjs) => {
+    const startDate = form.getFieldValue('startDate')
+    if (!startDate) {
+      return disablePastDates(current) // 시작 날짜가 없으면 현재 날짜 이전 비활성화
+    }
+    return current && (current < dayjs().startOf('day') || current < startDate)
+  }
+
   return (
     <Form
       form={form}
@@ -62,7 +76,11 @@ export default function AccompanyForm({
         />
       </Form.Item>
       <Form.Item name='startDate' label='시작 날짜'>
-        <DatePicker style={{ width: '100%' }} format='YYYY-MM-DD' />
+        <DatePicker
+          style={{ width: '100%' }}
+          format='YYYY-MM-DD'
+          disabledDate={disablePastDates} // 현재 날짜 이전 비활성화
+        />
       </Form.Item>
       <Form.Item
         name='endDate'
@@ -81,7 +99,11 @@ export default function AccompanyForm({
           }),
         ]}
       >
-        <DatePicker style={{ width: '100%' }} format='YYYY-MM-DD' />
+        <DatePicker
+          style={{ width: '100%' }}
+          format='YYYY-MM-DD'
+          disabledDate={disableEndDate} // 시작 날짜 이후만 선택 가능하도록 비활성화
+        />
       </Form.Item>
       <Form.Item
         name='content'

--- a/src/app/components/chat/GuestContent.tsx
+++ b/src/app/components/chat/GuestContent.tsx
@@ -233,7 +233,7 @@
 // export default GuestContent
 
 import ProfileIcon from '../common/ProfileIcon'
-import { Button } from 'antd'
+import { Button, Tag } from 'antd'
 import useAuthStore from '@/app/store/useAuthStore'
 import { CompanionUsers } from '@/interfaces'
 import { useRouter } from 'next/navigation'
@@ -249,12 +249,14 @@ interface GuestContentProps {
   companionUsers: CompanionUsers[] // 동행 참여자 목록
   postId: number // 게시글 ID
   isPostExists: boolean // 게시글 존재 여부
+  leaderId: number // 방장 ID
 }
 
 const GuestContent: React.FC<GuestContentProps> = ({
   companionUsers,
   postId,
   isPostExists,
+  leaderId,
 }) => {
   const { nickname, userId } = useAuthStore() // zustand 스토어에서 유저 닉네임 가져오기
   // TODO : 위치 정보 전송 시, 링크를 저장할 수 있는 상태 추가  - 관련 로직 추가 후 삭제 필요
@@ -323,6 +325,8 @@ const GuestContent: React.FC<GuestContentProps> = ({
                 nickname={user.memberNickname}
               />
               <div className='text-m font-semibold'>{user.memberNickname}</div>
+              {/* 방장 여부를 확인하고 표시 */}
+              {user.memberId === leaderId && <Tag color='#b3bbee'>방장</Tag>}
             </div>
           </div>
         ))}

--- a/src/app/components/chat/MenuDrawer.tsx
+++ b/src/app/components/chat/MenuDrawer.tsx
@@ -125,6 +125,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ chatRoomData }) => {
                         companionUsers={companionUsers}
                         postId={postId}
                         isPostExists={isPostExists}
+                        leaderId={leaderId}
                       />
                     ),
                   },
@@ -139,6 +140,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ chatRoomData }) => {
                         companionUsers={companionUsers}
                         postId={postId}
                         isPostExists={isPostExists}
+                        leaderId={leaderId}
                       />
                     ),
                   },

--- a/src/app/constants/protectedRoutes.ts
+++ b/src/app/constants/protectedRoutes.ts
@@ -5,4 +5,4 @@ export const protectedRoutes = ['/accompany', '/chat', '/community', '/profile']
 export const signupOnlyRoutes = ['/signup', '/privacy', '/policy']
 
 // 로그인이 되면 접근할 수 없는 페이지 목록
-export const guestRoutes = ['/', 'signup']
+export const guestRoutes = ['/']

--- a/src/app/hooks/useHandleDeleteClick.tsx
+++ b/src/app/hooks/useHandleDeleteClick.tsx
@@ -21,8 +21,6 @@ export const useHandleDeleteClick = () => {
             showSuccess(`${text}이 취소되었습니다.`)
             if (redirectPath) {
               router.push(redirectPath)
-            } else {
-              window.location.reload()
             }
           } catch {
             showError(`${text} 취소에 실패했습니다.`)

--- a/src/app/utils/fetchUtils.ts
+++ b/src/app/utils/fetchUtils.ts
@@ -7,11 +7,25 @@ import { Comment, ChatRoomEntryData } from '@/interfaces/index'
 export const fetchPost = async (postId: number) => {
   try {
     const data = await api.get(`/api/v1/accompany/posts/${postId}`)
+    console.log(data)
     return {
       ...data,
       createdAt: formatToUtcDate(data.createdAt),
       startDate: data.startDate ? formatShortDateFromUtc(data.startDate) : null,
       endDate: data.endDate ? formatShortDateFromUtc(data.endDate) : null,
+    }
+  } catch (error) {
+    console.error('Failed to fetch post:', error)
+    throw new Error('게시글을 불러오는 데 실패했습니다.')
+  }
+}
+
+// 게시글 수정 페이지에서 데이터를 가져오는 유틸리티 함수
+export const fetchEditPost = async (postId: number) => {
+  try {
+    const data = await api.get(`/api/v1/accompany/posts/${postId}`)
+    return {
+      data,
     }
   } catch (error) {
     console.error('Failed to fetch post:', error)

--- a/src/app/utils/fetchUtils.ts
+++ b/src/app/utils/fetchUtils.ts
@@ -7,7 +7,6 @@ import { Comment, ChatRoomEntryData } from '@/interfaces/index'
 export const fetchPost = async (postId: number) => {
   try {
     const data = await api.get(`/api/v1/accompany/posts/${postId}`)
-    console.log(data)
     return {
       ...data,
       createdAt: formatToUtcDate(data.createdAt),

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -40,6 +40,14 @@ export interface Post {
   urlQrPath: string
 }
 
+export interface EditPost {
+  title: string
+  accompanyArea: string
+  startDate: string
+  endDate: string
+  content: string
+}
+
 export interface PostCardProps {
   title: string
   content: string

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,9 @@ import {
 } from './app/constants/protectedRoutes'
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|fonts|images).*)'],
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|fonts|images|logo.svg).*)',
+  ],
 }
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## 📝 개요

- 배포사이트의 치명적인 이슈 해결이 되었습니다.
  - 추가입력폼 회원가입 페이지에서 로고깨짐 현상 
  - 동행게시글 수정페이지에서 시작/종료 날짜 표기 2001년으로 표기되는 이슈
  - 동행게시글 수정페이지에서 시작/종료 날짜 선택안했던 글일때 Invalid date로 표기되는 이슈
- 기타 성능 개선
  - 동행게시글 시작/종료날짜 선택 시, 오늘보다 이전날짜 선택 못하도록 로직 추가 
    - 시작날짜 존재할 때, 종료날짜는 시작날짜 이후부터 선택가능
  - 채팅방 햄버거바에 방장 표시 추가
  
## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 항목 1
  - ✨ 항목 2
  - ✨ 항목 3

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략)
  - 예: closes #123, resolves #456

## 📸 스크린샷 (옵션)

- UI 변경 사항이 있는 경우 스크린샷을 포함합니다.
- 해결된 화면 캡쳐목록
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5ce66f32-525a-46b7-985d-6807c6f2c343">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8ae38689-a883-4f5f-9d39-571d5fff83fc">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bb162d04-7ccd-40de-b4b8-de646f49cf84">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fee97ed7-7619-457b-b01f-cc4ce76c2600">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7bf5af69-540d-47ce-a5cb-423e4191bb52">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1ecdaa1f-3f3e-4950-9f4e-6121cc9e56fa">


## ℹ️ 참고 사항

- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함합니다.
