### PR TITLE
🐛 HotFix : 비로그인 유저가 바텀네비바를 통해 동행 페이지 접근 권한 가능한 이슈 제거

### DIFF
--- a/src/app/components/common/BottomNav.tsx
+++ b/src/app/components/common/BottomNav.tsx
@@ -44,6 +44,10 @@ const BottomNav: React.FC = () => {
   ]
 
   const handleTabClick = (path: string) => {
+    // 현재 경로가 '/' 또는 '/signup'인 경우 페이지 이동을 막음
+    if (pathname === '/' || pathname === '/signup') {
+      return
+    }
     router.push(path)
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ import {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|fonts|images|logo.svg).*)',
+    '/((?!_next/static|_next/image|favicon.ico|fonts|images|.*\\.svg$).*)',
   ],
 }
 


### PR DESCRIPTION
## 📝 개요

- 로그인이 필요한 '/' 경로에서 특정 조건마다 동행페이지로의 이동이 가능한 이슈 해결

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 항목 1
  - ✨ 항목 2
  - ✨ 항목 3

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략)
  - 예: closes #123, resolves #456

## 📸 스크린샷 (옵션)

- UI 변경 사항이 있는 경우 스크린샷을 포함합니다.
문제상황 캡쳐 : 토큰없는데 동행 페이지로 접근가능이슈
<img width="300" alt="image" src="https://github.com/user-attachments/assets/72abc80b-d3fb-4884-a1e1-3adfdfc6dc83">

## ℹ️ 참고 사항

- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함합니다.
